### PR TITLE
Fixed bug in checking for disabled statistics option. Fixed the corresponding test case also.

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/guice/EnvironmentVariablesDatabaseConfig.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/guice/EnvironmentVariablesDatabaseConfig.java
@@ -1,17 +1,11 @@
 package net.thucydides.core.guice;
 
-import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.statistics.database.LocalDatabase;
 import net.thucydides.core.util.EnvironmentVariables;
-import org.apache.commons.lang3.StringUtils;
 
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -91,7 +85,7 @@ public class EnvironmentVariablesDatabaseConfig implements DatabaseConfig {
     }
 
     private boolean isStatisticsDisabled() {
-        return (Boolean.valueOf(environmentVariables.getProperty(ThucydidesSystemProperty.RECORD_STATISTICS, "true")));
+        return (! Boolean.valueOf(environmentVariables.getProperty(ThucydidesSystemProperty.RECORD_STATISTICS, "true")));
     }
 
     @Override

--- a/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/HibernateTestOutcomeHistoryDAO.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/HibernateTestOutcomeHistoryDAO.java
@@ -273,6 +273,18 @@ public class HibernateTestOutcomeHistoryDAO implements TestOutcomeHistoryDAO {
     }
 
     @Override
+    public void truncateSchema() {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        entityManager.getTransaction().begin();
+        try {
+            entityManager.createNativeQuery("TRUNCATE SCHEMA PUBLIC RESTART IDENTITY AND COMMIT NO CHECK").executeUpdate();
+            entityManager.getTransaction().commit();
+        }catch(Exception e) {
+            entityManager.getTransaction().rollback();
+        }
+    }
+
+    @Override
     public Long countTestRunsByTitle(String title) {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
         return (Long) entityManager.createQuery(COUNT_BY_NAME)

--- a/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/TestOutcomeHistoryDAO.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/TestOutcomeHistoryDAO.java
@@ -45,4 +45,6 @@ public interface TestOutcomeHistoryDAO {
     List<String> findAllTagTypes();
 
     List<TestRunTag> findTagsMatching(TestRunTag tag);
+
+    void truncateSchema();
 }

--- a/thucydides-core/src/test/java/net/thucydides/core/statistics/WhenRecordingTestResultStatistics.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/statistics/WhenRecordingTestResultStatistics.java
@@ -27,22 +27,18 @@ import net.thucydides.core.util.MockEnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
 import org.joda.time.DateTime;
+import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import java.util.List;
 
 import static net.thucydides.core.matchers.dates.DateMatchers.isSameAs;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 
 public class WhenRecordingTestResultStatistics {
@@ -113,6 +109,16 @@ public class WhenRecordingTestResultStatistics {
         prepareTestData(statisticsListener);
     }
 
+    @After
+    public void cleanup() {
+        ThucydidesModuleWithMockEnvironmentVariables guiceModule = new ThucydidesModuleWithMockEnvironmentVariables();
+        Injector injector = Guice.createInjector(guiceModule);
+        testOutcomeHistoryDAO = injector.getInstance(HibernateTestOutcomeHistoryDAO.class);
+        testOutcomeHistoryDAO.truncateSchema();
+
+    }
+
+
     @Test
     public void should_be_able_to_obtain_the_statistics_listener_via_guice() {
         StepListener statisticsListener = injector.getInstance(Key.get(StepListener.class, Statistics.class));
@@ -169,9 +175,11 @@ public class WhenRecordingTestResultStatistics {
         ThucydidesModuleWithMockEnvironmentVariables guiceModule = new ThucydidesModuleWithMockEnvironmentVariables();
         Injector injector = Guice.createInjector(guiceModule);
         EnvironmentVariables environmentVariables = injector.getInstance(EnvironmentVariables.class);
+        environmentVariables.setProperty("thucydides.statistics.url", "jdbc:hsqldb:mem:defaultTestDatabase");
         environmentVariables.setProperty("thucydides.record.statistics", "false");
 
         TestOutcomeHistoryDAO testOutcomeHistoryDAO = injector.getInstance(HibernateTestOutcomeHistoryDAO.class);
+        DatabaseConfig databaseConfig = injector.getInstance(DatabaseConfig.class);
         StatisticsListener statisticsListener = new StatisticsListener(testOutcomeHistoryDAO, environmentVariables, databaseConfig);
         HibernateTestStatisticsProvider testStatisticsProvider = new HibernateTestStatisticsProvider(testOutcomeHistoryDAO);
 


### PR DESCRIPTION
John,

The isStatisticsDisabled() method should return true if the statistics are disabled (i.e., when the flag is set to false). Right now, this method is doing the opposite.

Further, the test case was failing because of two reasons
1. By default it was using the h2 database. If an h2 schema already exists, the value of storedTestRuns.size() could be non-zero. So I changed the test to always use hsqldb.
2. Even with hsqldb, this test was failing because a record gets inserted in the dstabase from the previous test case. So I have written a small method to truncate the schema after every test case run. 

Please review. 
