### PR TITLE
Renamed truncateSchema to deleteAll and modified logic to delete all tes...

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/HibernateTestOutcomeHistoryDAO.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/HibernateTestOutcomeHistoryDAO.java
@@ -273,15 +273,20 @@ public class HibernateTestOutcomeHistoryDAO implements TestOutcomeHistoryDAO {
     }
 
     @Override
-    public void truncateSchema() {
+    public void deleteAll() {
         EntityManager entityManager = entityManagerFactory.createEntityManager();
-        entityManager.getTransaction().begin();
         try {
-            entityManager.createNativeQuery("TRUNCATE SCHEMA PUBLIC RESTART IDENTITY AND COMMIT NO CHECK").executeUpdate();
+
+            List<TestRun> testRuns  = findAll();
+            entityManager.getTransaction().begin();
+            for(TestRun testRun: testRuns) {
+                entityManager.remove(entityManager.merge(testRun));
+            }
             entityManager.getTransaction().commit();
         }catch(Exception e) {
             entityManager.getTransaction().rollback();
         }
+
     }
 
     @Override

--- a/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/TestOutcomeHistoryDAO.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/statistics/dao/TestOutcomeHistoryDAO.java
@@ -46,5 +46,5 @@ public interface TestOutcomeHistoryDAO {
 
     List<TestRunTag> findTagsMatching(TestRunTag tag);
 
-    void truncateSchema();
+    void deleteAll();
 }

--- a/thucydides-core/src/test/java/net/thucydides/core/statistics/WhenRecordingTestResultStatistics.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/statistics/WhenRecordingTestResultStatistics.java
@@ -27,7 +27,6 @@ import net.thucydides.core.util.MockEnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
 import org.joda.time.DateTime;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -109,16 +108,6 @@ public class WhenRecordingTestResultStatistics {
         prepareTestData(statisticsListener);
     }
 
-    @After
-    public void cleanup() {
-        ThucydidesModuleWithMockEnvironmentVariables guiceModule = new ThucydidesModuleWithMockEnvironmentVariables();
-        Injector injector = Guice.createInjector(guiceModule);
-        testOutcomeHistoryDAO = injector.getInstance(HibernateTestOutcomeHistoryDAO.class);
-        testOutcomeHistoryDAO.truncateSchema();
-
-    }
-
-
     @Test
     public void should_be_able_to_obtain_the_statistics_listener_via_guice() {
         StepListener statisticsListener = injector.getInstance(Key.get(StepListener.class, Statistics.class));
@@ -179,12 +168,11 @@ public class WhenRecordingTestResultStatistics {
         environmentVariables.setProperty("thucydides.record.statistics", "false");
 
         TestOutcomeHistoryDAO testOutcomeHistoryDAO = injector.getInstance(HibernateTestOutcomeHistoryDAO.class);
+        testOutcomeHistoryDAO.deleteAll();
         DatabaseConfig databaseConfig = injector.getInstance(DatabaseConfig.class);
         StatisticsListener statisticsListener = new StatisticsListener(testOutcomeHistoryDAO, environmentVariables, databaseConfig);
         HibernateTestStatisticsProvider testStatisticsProvider = new HibernateTestStatisticsProvider(testOutcomeHistoryDAO);
-
         prepareTestData(statisticsListener);
-
         prepareDAOWithFixedClock();
 
         when(testOutcome.getResult()).thenReturn(TestResult.SUCCESS);


### PR DESCRIPTION
...t runs instead of truncating schema. This makes it more generic. Also modified the test case to directly call this method instead of setting this up as an "After" method to ensure that the correct DAO (and Database configuration) is used.
