### PR TITLE
Get rid of URL object comparation

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/Pages.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/Pages.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -81,13 +82,13 @@ public class Pages implements Serializable {
 
     private boolean currentUrlIs(String startingUrl) {
         String currentUrl = getDriver().getCurrentUrl();
-        if ((currentUrl != null) && (startingUrl != null)) {
-            try {
-                return new URL(currentUrl).equals(new URL(startingUrl));
-            } catch (MalformedURLException e) {
-                return false;
-            }
-        } else {
+        if (currentUrl == null || startingUrl == null) {
+            return false;
+        }
+
+        try {
+            return URI.create(currentUrl).equals(URI.create(startingUrl));
+        } catch (IllegalArgumentException e) {
             return false;
         }
     }


### PR DESCRIPTION
It's better avoid comparing two URLs by calling equals() method on URL object. This method was implemented long ago so it has very strange behaviour - it tries to do dns lookup for comparing hosts through comparing its IP adresses. So it may return incorrect results for websites based on virtual hosting and has some other serious problems.

You may read about this strange behaviour in javadoc: http://docs.oracle.com/javase/6/docs/api/java/net/URL.html#equals(java.lang.Object)
