### PR TITLE
Fixed bug that was causing nested HTMLtables to return bad data. 

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/components/HtmlTable.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/components/HtmlTable.java
@@ -160,7 +160,7 @@ public class HtmlTable {
     }
 
     private boolean hasMatchingCellValuesIn(WebElement firstRow, List<String> headings) {
-        List<WebElement> cells = firstRow.findElements(By.tagName("td"));
+        List<WebElement> cells = firstRow.findElements(By.xpath("./td"));
         for(int cellIndex = 0; cellIndex < headings.size(); cellIndex++) {
             if ((cells.size() < cellIndex) || (!cells.get(cellIndex).getText().equals(headings.get(cellIndex)))) {
                 return false;
@@ -224,7 +224,7 @@ public class HtmlTable {
     }
 
     private List<WebElement> cellsIn(WebElement row) {
-        return row.findElements(By.tagName("td"));
+        return row.findElements(By.xpath("./td"));
     }
 
     private String cellValueAt(final int column, final List<WebElement> cells) {

--- a/thucydides-core/src/test/java/net/thucydides/core/pages/integration/ReadingTableData.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/pages/integration/ReadingTableData.java
@@ -128,6 +128,19 @@ public class ReadingTableData extends FluentElementAPITestsBaseClass {
     }
 
     @Test
+    public void should_read_table_data_from_a_nested_table() {
+        HtmlTable table = new HtmlTable(page.clients_with_nested_cells);
+        List<Map<Object, String>> tableRows = HtmlTable.rowsFrom(page.clients_with_nested_cells);
+
+        assertThat(tableRows.size(), is(3));
+        assertThat(tableRows.get(0), allOf(hasEntry("First Names", "TimothyTim"), hasEntry("Last Name", "Brooke-Taylor"), hasEntry("Favorite Colour", "Red")));
+        assertThat(tableRows.get(1), allOf(hasEntry("First Names", "GraemeGarry"), hasEntry("Last Name", "Garden"), hasEntry("Favorite Colour", "Green")));
+        assertThat(tableRows.get(2), allOf(hasEntry("First Names", "WilliamBill"),hasEntry("Last Name", "Oddie"), hasEntry("Favorite Colour","Blue")));
+
+    }
+
+
+    @Test
     public void should_manipulate_table_data_for_a_table_with_no_heading() {
         boolean containsRowElements = HtmlTable.withColumns("First Name","Last Name", "Favorite Colour")
                  .inTable(page.clients_with_no_headings).containsRowElementsWhere(the("First Name", is("Tim")), the("Last Name", containsString("Taylor")));

--- a/thucydides-core/src/test/java/net/thucydides/core/pages/integration/StaticSitePage.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/pages/integration/StaticSitePage.java
@@ -76,6 +76,8 @@ import org.openqa.selenium.support.ui.ExpectedCondition;
 
         protected WebElement clients_with_no_headings;
 
+        protected WebElement clients_with_nested_cells;
+
         protected WebElement clients_with_extra_cells;
 
         protected WebElement clients_with_missing_cells;

--- a/thucydides-core/src/test/resources/static-site/index.html
+++ b/thucydides-core/src/test/resources/static-site/index.html
@@ -187,6 +187,25 @@
     <tr><td><a href="#">Bill</a></td><td>Oddie</td><td>Blue</td></tr>
 </table>
 
+
+<table id="clients_with_nested_cells">
+    <thead>
+    <tr>
+        <th>First Names</th>
+        <th>Last Name</th>
+        <th>Favorite Colour</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr><td><table><tr><td><a href="#">Timothy</a></td><td><a href="#">Tim</a></td></tr></table>
+        </td><td>Brooke-Taylor</td><td>Red</td></tr>
+        <tr><td><table><tr><td><a href="#">Graeme</a></td><td><a href="#">Garry</a></td></tr></table>
+        </td><td>Garden</td><td>Green</td></tr>
+        <tr><td><table><tr><td><a href="#">William</a></td><td><a href="#">Bill</a></td></tr></table>
+        </td><td>Oddie</td><td>Blue</td></tr>
+    </tbody>
+</table>
+
 <table id="clients_with_extra_cells">
     <thead>
     <tr>


### PR DESCRIPTION
Nested table now returns values of all tags concatenated. This is still not perfect but at least the user issue is resolved. Ref: http://java.net/projects/thucydides/lists/users/archive/2012-09/message/3

Please see test case ReadingTableData.should_read_table_data_from_a_nested_table to see how this is implemented.
