### PR TITLE
Modified to display full error message as tool tip (#Thucydides-90)

### DIFF
--- a/thucydides-report-resources/src/main/resources/freemarker/default.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/default.ftl
@@ -181,7 +181,7 @@
                         <#if step.result == "FAILURE" && !step.isAGroup()>
                             <tr class="test-${step.result}">
                                 <td width="40">&nbsp</td>
-                                <td width="%" colspan="4"><span class="error-message">${step.shortErrorMessage!''}</span></td>
+                                <td width="%" colspan="4"><span class="error-message" title="${step.errorMessage?html!''}">${step.shortErrorMessage!''}</span></td>
                             </tr>
                         </#if>
                 </#macro>


### PR DESCRIPTION
Detailed error message is now displayed as tool-tip on the short error message.
