### PR TITLE
Changes to shouldContainText and shouldNotContainText messaging

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacade.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacade.java
@@ -255,6 +255,13 @@ public class WebElementFacade {
     }
 
     /**
+     * Does this element exactly match  given text?
+     */
+    public boolean containsOnlyText(final String value) {
+        return ((webElement != null) && (webElement.getText().equals(value)));
+    }
+
+    /**
      * Does this dropdown contain the specified value.
      */
     public boolean containsSelectOption(final String value) {
@@ -288,6 +295,15 @@ public class WebElementFacade {
         }
     }
 
+    /**
+     * Check that an element exactly matches a text value
+     *
+     * @param textValue
+     */
+    public void shouldContainOnlyText(String textValue) {
+        if (!containsOnlyText(textValue)) {
+            String errorMessage = String.format(
+                    "The text '%s' does not match the elements text '%s'.", textValue, webElement.getText());
             throw new AssertionError(errorMessage);
         }
     }

--- a/thucydides-core/src/test/java/net/thucydides/core/pages/integration/CheckingFieldContentWithTheFluentElementAPI.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/pages/integration/CheckingFieldContentWithTheFluentElementAPI.java
@@ -41,6 +41,11 @@ public class CheckingFieldContentWithTheFluentElementAPI extends FluentElementAP
     }
 
     @Test
+    public void should_contain_only_text_passes_if_field_contains_only_text() {
+        page.element(page.nonEmptyLabel).shouldContainOnlyText("This div tag has text");
+    }
+
+    @Test
     public void should_contain_entry_passes_if_dropdown_contains_text() {
         page.element(page.colors).shouldContainSelectedOption("Red");
     }
@@ -93,6 +98,11 @@ public class CheckingFieldContentWithTheFluentElementAPI extends FluentElementAP
     @Test(expected = AssertionError.class)
     public void should_contain_text_throws_exception_if_field_does_not_contain_text() {
         page.element(page.colors).shouldContainText("Magenta");
+    }
+
+    @Test(expected = AssertionError.class)
+    public void should_contain_only_text_throws_exception_if_field_does_not_contain_only_text() {
+        page.element(page.colors).shouldContainOnlyText("Magenta");
     }
 
     @Test(expected = NoSuchElementException.class)


### PR DESCRIPTION
shouldNotContainText error message was same as shouldContainText. Modified to accurately reflect the error condition.

Also, for both, now show the text found in the element as well as the expected text. I find this useful, and have created a customization in all my projects to handle this. Finally hoping to have it in core.

Once you've had a chance to review, let me know if you'd like anything changed or enhanced.
