### PR TITLE
Correct issues with Step Failure Analysis

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/webdriver/WebdriverAssertionError.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/webdriver/WebdriverAssertionError.java
@@ -8,7 +8,7 @@ public class WebdriverAssertionError extends AssertionError {
     private static final long serialVersionUID = 1L;
 
     public WebdriverAssertionError(String message, Throwable cause) {
-        super(message);
+        super(message, cause);
         this.setStackTrace(cause.getStackTrace());
     }
 }

--- a/thucydides-core/src/test/java/net/thucydides/core/model/FailureAnalysisTest.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/model/FailureAnalysisTest.java
@@ -1,0 +1,36 @@
+package net.thucydides.core.model;
+
+import net.thucydides.core.webdriver.WebdriverAssertionError;
+import org.junit.Test;
+import org.junit.internal.ArrayComparisonFailure;
+import org.omg.CORBA.COMM_FAILURE;
+
+import static junit.framework.Assert.assertEquals;
+
+public class FailureAnalysisTest {
+    private FailureAnalysis fixture = new FailureAnalysis();
+
+    @Test
+    public void an_assertionerror_is_a_failure() {
+        assertEquals(TestResult.FAILURE, fixture.resultFor(new AssertionError("test message")));
+    }
+    @Test
+    public void a_subclass_of_assertionerror_is_a_failure() {
+        assertEquals(TestResult.FAILURE, fixture.resultFor(new ArrayComparisonFailure("test message", new AssertionError("wrapped exception"), 1)));
+    }
+
+    @Test
+    public void a_webdriverassertion_with_assertionerror_cause_is_a_failure() {
+        assertEquals(TestResult.FAILURE, fixture.resultFor(new WebdriverAssertionError("expect failure", new AssertionError("wrapped assertion error"))));
+    }
+
+    @Test
+    public void a_non_assertion_error_is_an_error() {
+        assertEquals(TestResult.ERROR, fixture.resultFor(new RuntimeException("message")));
+    }
+
+    @Test
+    public void a_webdriverassertion_with_a_non_assertion_cause_is_an_error() throws Exception {
+        assertEquals(TestResult.ERROR, fixture.resultFor(new WebdriverAssertionError("expect error", new NullPointerException())));
+    }
+}


### PR DESCRIPTION
Store cause in WebdriverAssertionError. This allows it to be checked in FailureAnalysis.

Modify FailureAnalysis so that it will return Failure if the error is an AssertionError (or subclass), or the error is a WebdriverAssertionError and the cause is an AssertionError.

All other scenarios will return Error.
