### PR TITLE
Allow for enter(value).into(field) where field is a WebElementFacade

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
@@ -837,10 +837,13 @@ public abstract class PageObject {
             element(field).type(value);
         }
 
+        public void into(final WebElementFacade field) {
+            field.type(value);
+        }
+
         public void intoField(final By bySelector) {
             WebElement field = getDriver().findElement(bySelector);
-            element(field).type(value);
-
+            into(field);
         }
     }
 

--- a/thucydides-core/src/test/java/net/thucydides/core/pages/integration/WhenManagingAPageObject.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/pages/integration/WhenManagingAPageObject.java
@@ -1,6 +1,7 @@
 package net.thucydides.core.pages.integration;
 
 import net.thucydides.core.pages.PageObject;
+import net.thucydides.core.pages.WebElementFacade;
 import net.thucydides.core.util.MockEnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.SystemPropertiesConfiguration;
@@ -390,13 +391,27 @@ public class WhenManagingAPageObject {
     }
 
     @Test
-    public void should_provide_a_fluent_api_for_entering_a_value_in_a_field() {
+    public void should_provide_a_fluent_api_for_entering_a_value_in_a_field_using_webelement() {
         WebElement field = mock(WebElement.class);
         BasicPageObject page = new BasicPageObject(driver);
         when(field.isEnabled()).thenReturn(true);
         when(field.getTagName()).thenReturn("input");
 
         page.enter("some value").into(field);
+
+        verify(field).clear();
+        verify(field).sendKeys("some value");
+    }
+
+    @Test
+    public void should_provide_a_fluent_api_for_entering_a_value_in_a_field_using_webelementfacade() {
+        WebElement field = mock(WebElement.class);
+        WebElementFacade facade = new WebElementFacade(driver, field, 0L);
+        BasicPageObject page = new BasicPageObject(driver);
+        when(field.isEnabled()).thenReturn(true);
+        when(field.getTagName()).thenReturn("input");
+
+        page.enter("some value").into(facade);
 
         verify(field).clear();
         verify(field).sendKeys("some value");


### PR DESCRIPTION
Now that all PageObjects can instantiate WebElementFacade fields, and I don't see a reason not to use them everywhere, it would be nice to be able to use the fluent enter(value).into(field).

A simple method addition to FieldEntry.
