### PR TITLE
Bugfix THUCYDIDES-149

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/reports/xml/TestOutcomeConverter.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/reports/xml/TestOutcomeConverter.java
@@ -112,7 +112,7 @@ public class TestOutcomeConverter implements Converter {
         writer.addAttribute(SKIPPED_FIELD, Integer.toString(testOutcome.getSkippedCount()));
         writer.addAttribute(IGNORED_FIELD, Integer.toString(testOutcome.getIgnoredCount()));
         writer.addAttribute(PENDING_FIELD, Integer.toString(testOutcome.getPendingCount()));
-        writer.addAttribute(RESULT_FIELD, testOutcome.getResult().toString());
+        writer.addAttribute(RESULT_FIELD, testOutcome.getResult().name());
         writer.addAttribute(DURATION, Long.toString(testOutcome.getDuration()));
         if (isNotEmpty(testOutcome.getSessionId())) {
             writer.addAttribute(SESSION_ID, testOutcome.getSessionId());
@@ -341,6 +341,7 @@ public class TestOutcomeConverter implements Converter {
         String methodName = reader.getAttribute(NAME_FIELD);
         TestOutcome testOutcome = new TestOutcome(methodName);
         testOutcome.setTitle(unescape(reader.getAttribute(TITLE_FIELD)));
+        TestResult savedTestResult = TestResult.valueOf(reader.getAttribute(RESULT_FIELD));
         if (reader.getAttribute(QUALIFIER_FIELD) != null) {
             testOutcome = testOutcome.withQualifier(unescape(reader.getAttribute(QUALIFIER_FIELD)));
         }
@@ -349,6 +350,9 @@ public class TestOutcomeConverter implements Converter {
         String sessionId = readSessionId(reader);
         testOutcome.setSessionId(sessionId);
         readChildren(reader, testOutcome);
+        if(testOutcome.getStepCount().equals(0)) {
+            testOutcome.setAnnotatedResult(savedTestResult);
+        }
         return testOutcome;
     }
 

--- a/thucydides-core/src/test/groovy/net/thucydides/core/reports/WhenObtainingResultSummariesFromTestOutcomes.groovy
+++ b/thucydides-core/src/test/groovy/net/thucydides/core/reports/WhenObtainingResultSummariesFromTestOutcomes.groovy
@@ -24,6 +24,7 @@ class WhenObtainingResultSummariesFromTestOutcomes extends Specification {
             directory                                  | result
             "/test-outcomes/all-successful"            | TestResult.SUCCESS
             "/test-outcomes/containing-failure"        | TestResult.FAILURE
+            "/test-outcomes/containing-nostep-errors"  | TestResult.FAILURE
             "/test-outcomes/containing-errors"         | TestResult.ERROR
             "/test-outcomes/containing-pending"        | TestResult.PENDING
             "/test-outcomes/containing-skipped"        | TestResult.SUCCESS
@@ -42,6 +43,7 @@ class WhenObtainingResultSummariesFromTestOutcomes extends Specification {
             directory                                  | successCount | failureCount | errorCount   | pendingCount | skipCount
             "/test-outcomes/all-successful"            | 3            | 0            | 0            | 0            | 0
             "/test-outcomes/containing-failure"        | 1            | 1            | 0            | 1            | 0
+            "/test-outcomes/containing-nostep-errors"  | 1            | 2            | 1            | 1            | 0
             "/test-outcomes/containing-errors"         | 1            | 0            | 2            | 0            | 0
             "/test-outcomes/containing-pending"        | 2            | 0            | 0            | 1            | 0
             "/test-outcomes/containing-skipped"        | 3            | 0            | 0            | 0            | 1
@@ -53,7 +55,7 @@ class WhenObtainingResultSummariesFromTestOutcomes extends Specification {
         then:
             testOutcomes.stepCount == 17
     }
-    
+
     def "should calculate the percentage of passing steps"() {
         when:
             def testOutcomes = TestOutcomeLoader.testOutcomesIn(directoryInClasspathCalled(directory));
@@ -99,13 +101,16 @@ class WhenObtainingResultSummariesFromTestOutcomes extends Specification {
         then:
         testOutcomes.decimalPercentagePassingTestCount == percentagePassing &&
                 testOutcomes.decimalPercentageFailingTestCount == percentageFailing &&
+                testOutcomes.decimalPercentageErrorTestCount == percentageErroring &&
                 testOutcomes.decimalPercentagePendingTestCount == percentagePending
         where:
-        directory                                  | percentagePassing | percentageFailing  | percentagePending
-        "/test-outcomes/all-successful"            | "1"                 | "0"                | "0"
-        "/test-outcomes/containing-failure"        | "0.33"              | "0.33"             | "0.33"
-        "/test-outcomes/containing-pending"        | "0.67"              | "0"                | "0.33"
-        "/test-outcomes/all-pending"               | "0"                 | "0"                | "1"
+        directory                                 | percentagePassing | percentageFailing | percentageErroring | percentagePending
+        "/test-outcomes/all-successful"           | "1"               | "0"               | "0"                | "0"
+        "/test-outcomes/containing-failure"       | "0.33"            | "0.33"            | "0"                | "0.33"
+        "/test-outcomes/containing-pending"       | "0.67"            | "0"               | "0"                | "0.33"
+        "/test-outcomes/containing-nostep-errors" | "0.2"             | "0.4"             | "0.2"              | "0.2"
+        "/test-outcomes/containing-errors"        | "0.33"            | "0"               | "0.67"             | "0"
+        "/test-outcomes/all-pending"              | "0"               | "0"               | "0"                | "1"
     }
 
     def "should provide a formatted version of the failing coverage metrics"() {

--- a/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-1.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-1.xml
@@ -1,0 +1,39 @@
+<acceptance-test-run title="An acceptance test run" name="an_acceptance_test_run" steps="8" successful="8" failures="0" skipped="0" ignored="0" pending="0" duration="1000" result="SUCCESS">
+  <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
+     <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
+  </user-story>
+  <tags>
+      <tag name="a feature" type="feature"/>
+      <tag name="a story" type="story"/>
+  </tags>
+  <test-step result="SUCCESS">
+    <description>The customer navigates from metro jobs link.</description>
+    <screenshot>the_customer_navigates_from_metro_jobs_link1.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer navigates to the metro masthead site.</description>
+    <screenshot>the_customer_navigates_to_the_metro_masthead_site2.png</screenshot>
+  </test-step>
+  <test-group name="Do something important" result="SUCCESS">
+      <test-step result="SUCCESS">
+          <description>The customer navigates to classified place ad page.</description>
+          <screenshot>the_customer_navigates_to_classified_place_ad_page3-1.png</screenshot>
+      </test-step>
+      <test-step result="SUCCESS">
+          <description>The customer navigates to classified place ad page.</description>
+          <screenshot>the_customer_navigates_to_classified_place_ad_page3-2.png</screenshot>
+      </test-step>
+      <test-step result="SUCCESS">
+          <description>The customer navigates to classified place ad page.</description>
+          <screenshot>the_customer_navigates_to_classified_place_ad_page3-3.png</screenshot>
+      </test-step>
+  </test-group>
+  <test-step result="SUCCESS">
+    <description>The customer chooses the jobs section.</description>
+    <screenshot>the_customer_chooses_the_jobs_section4.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer selects a run option.</description>
+    <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+  </test-step>
+</acceptance-test-run>

--- a/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-2.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-2.xml
@@ -1,0 +1,52 @@
+<acceptance-test-run title="Another acceptance test run" name="another_acceptance_test_run"  steps="6" successful="5" failures="0" skipped="0" ignored="0" pending="1" duration="1000" result="PENDING">
+  <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
+     <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
+  </user-story>
+    <tags>
+        <tag name="a feature" type="feature"/>
+        <tag name="another story" type="story"/>
+    </tags>
+  <test-step result="SUCCESS">
+    <description>The customer navigates from metro jobs link.</description>
+    <screenshot>the_customer_navigates_from_metro_jobs_link1.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer navigates to the metro masthead site.</description>
+    <screenshot>the_customer_navigates_to_the_metro_masthead_site2.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer navigates to classified place ad page.</description>
+    <screenshot>the_customer_navigates_to_classified_place_ad_page3.png</screenshot>
+  </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+    <test-step result="SUCCESS">
+        <description>The customer selects a run option.</description>
+        <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+    </test-step>
+  <test-step result="PENDING">
+    <description>The customer provides email address for registration.</description>
+  </test-step>
+</acceptance-test-run>

--- a/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-3.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-3.xml
@@ -1,0 +1,32 @@
+<acceptance-test-run title="A different acceptance test run" name="a_different_acceptance_test_run"  steps="6" successful="5" failures="1" skipped="0" ignored="0" pending="0" duration="1000" result="FAILURE">
+  <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
+     <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
+  </user-story>
+    <tags>
+        <tag name="an epic" type="epic"/>
+        <tag name="another different story" type="story"/>
+    </tags>
+  <test-step result="SUCCESS">
+    <description>The customer navigates from metro jobs link.</description>
+    <screenshot>the_customer_navigates_from_metro_jobs_link1.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer navigates to the metro masthead site.</description>
+    <screenshot>the_customer_navigates_to_the_metro_masthead_site2.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer navigates to classified place ad page.</description>
+    <screenshot>the_customer_navigates_to_classified_place_ad_page3.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer chooses the jobs section.</description>
+    <screenshot>the_customer_chooses_the_jobs_section4.png</screenshot>
+  </test-step>
+  <test-step result="SUCCESS">
+    <description>The customer selects a run option.</description>
+    <screenshot>the_customer_selects_a_run_option5.png</screenshot>
+  </test-step>
+  <test-step result="FAILURE">
+    <description>The customer provides email address for registration.</description>
+  </test-step>
+</acceptance-test-run>

--- a/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-4.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-4.xml
@@ -1,0 +1,9 @@
+<acceptance-test-run title="Another test that failed, but no steps" name="noStepFailure" steps="0" successful="0" failures="0" skipped="0" ignored="0" pending="0" result="FAILURE" duration="34">
+    <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
+        <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
+    </user-story>
+    <tags>
+        <tag name="a feature" type="feature"/>
+        <tag name="another story" type="story"/>
+    </tags>
+</acceptance-test-run>

--- a/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-5.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/containing-nostep-errors/sample-report-5.xml
@@ -1,0 +1,9 @@
+<acceptance-test-run title="Test with no steps that had an error" name="noStepError" steps="0" successful="0" failures="0" skipped="0" ignored="0" pending="0" result="ERROR" duration="34">
+    <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
+        <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
+    </user-story>
+    <tags>
+        <tag name="a feature" type="feature"/>
+        <tag name="another story" type="story"/>
+    </tags>
+</acceptance-test-run>

--- a/thucydides-core/src/test/resources/test-outcomes/with-no-steps/sample-report-2.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/with-no-steps/sample-report-2.xml
@@ -1,4 +1,4 @@
-<acceptance-test-run title="Another acceptance test run" name="another_acceptance_test_run"  steps="6" successful="5" failures="0" skipped="0" ignored="0" pending="1" duration="0" result="SUCCESS">
+<acceptance-test-run title="Another acceptance test run" name="another_acceptance_test_run"  steps="6" successful="5" failures="0" skipped="0" ignored="0" pending="1" duration="0" result="PENDING">
   <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
      <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
   </user-story>

--- a/thucydides-core/src/test/resources/test-outcomes/with-no-steps/sample-report-3.xml
+++ b/thucydides-core/src/test/resources/test-outcomes/with-no-steps/sample-report-3.xml
@@ -1,4 +1,4 @@
-<acceptance-test-run title="A different acceptance test run" name="a_different_acceptance_test_run"  steps="6" successful="5" failures="0" skipped="0" ignored="0" pending="1" duration="0" result="SUCCESS">
+<acceptance-test-run title="A different acceptance test run" name="a_different_acceptance_test_run"  steps="6" successful="5" failures="0" skipped="0" ignored="0" pending="1" duration="0" result="PENDING">
   <user-story id="net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature.AUserStoryInAFeature" name="A user story in a feature">
      <feature id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AFeature' name='A feature'/>
   </user-story>

--- a/thucydides-report-resources/src/main/resources/freemarker/capabilities.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/capabilities.ftl
@@ -388,7 +388,7 @@ Estimated unimplemented or pending requirements: ${pending}">
                                         <tbody>
                                             <#assign testResultSet = testOutcomes.tests >
                                             <#foreach testOutcome in testResultSet>
-                                                <#if testOutcome.stepCount == 0 || testOutcome.result == "PENDING" || testOutcome.result == "IGNORED">
+                                                <#if testOutcome.result == "PENDING" || testOutcome.result == "IGNORED">
                                                     <#assign testrun_outcome_icon = "pending.png">
                                                 <#elseif testOutcome.result == "FAILURE">
                                                     <#assign testrun_outcome_icon = "fail.png">

--- a/thucydides-report-resources/src/main/resources/freemarker/home.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/home.ftl
@@ -291,7 +291,7 @@
                                 <tbody>
                                 <#assign testResultSet = testOutcomes.tests >
                                 <#foreach testOutcome in testResultSet>
-                                    <#if testOutcome.stepCount == 0 || testOutcome.result == "PENDING" || testOutcome.result == "IGNORED">
+                                    <#if testOutcome.result == "PENDING" || testOutcome.result == "IGNORED">
                                         <#assign testrun_outcome_icon = "pending.png">
                                     <#elseif testOutcome.result == "FAILURE">
                                         <#assign testrun_outcome_icon = "fail.png">


### PR DESCRIPTION
Tests with no steps in xml will respect the result entry in the xml. Previously, always assumed this was a Pending test, but may have no steps in output because of an error or failure.

This impacts the header on the home page, as well as the icons used in the summary tables. I didn't see any issues with modifying the 2 .ftl pages to remove the 'force test with 0 steps to be pending' logic as that's basically what the TestOutcome.getResult eventually might do. The TestOutcome.result is now the source of truth.
