### PR TITLE
Move inline style definitions into css

### DIFF
--- a/thucydides-report-resources/src/main/resources/freemarker/default.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/default.ftl
@@ -14,24 +14,6 @@
     <link type="text/css" href="jqueryui/css/start/jquery-ui-1.8.18.custom.css" rel="Stylesheet" />
     <script type="text/javascript" src="jqueryui/js/jquery-ui-1.8.18.custom.min.js"></script>
 
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
-
-
 </head>
 
 <body>

--- a/thucydides-report-resources/src/main/resources/freemarker/history.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/history.ftl
@@ -6,22 +6,6 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="css/core.css"/>
     <link rel="stylesheet" type="text/css" href="jqplot/jquery.jqplot.min.css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
 
     <!--[if IE]>
     <script language="javascript" type="text/javascript" src="jit/Extras/excanvas.js"></script><![endif]-->

--- a/thucydides-report-resources/src/main/resources/freemarker/home.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/home.ftl
@@ -6,23 +6,6 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="css/core.css"/>
     <link rel="stylesheet" type="text/css" href="jqplot/jquery.jqplot.min.css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
-
 
     <!--[if IE]>
     <script language="javascript" type="text/javascript" src="jit/Extras/excanvas.js"></script><![endif]-->

--- a/thucydides-report-resources/src/main/resources/freemarker/progress-report.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/progress-report.ftl
@@ -8,23 +8,6 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="css/core.css"/>
     <link rel="stylesheet" type="text/css" href="jqplot/jquery.jqplot.min.css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
-
 
     <!--[if IE]>
     <script language="javascript" type="text/javascript" src="jit/Extras/excanvas.js"></script><![endif]-->

--- a/thucydides-report-resources/src/main/resources/freemarker/results-by-tagtype.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/results-by-tagtype.ftl
@@ -6,23 +6,6 @@
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="css/core.css"/>
     <link rel="stylesheet" type="text/css" href="jqplot/jquery.jqplot.min.css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
-
 
     <!--[if IE]>
     <script language="javascript" type="text/javascript" src="jit/Extras/excanvas.js"></script><![endif]-->

--- a/thucydides-report-resources/src/main/resources/freemarker/screenshot.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/screenshot.ftl
@@ -12,22 +12,6 @@
     <link rel="shortcut icon" href="favicon.ico" >
     <link href="css/core.css" rel="stylesheet" type="text/css"/>
     <script src="scripts/jquery.js" type="text/javascript"></script>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
 </head>
 
 <body>

--- a/thucydides-report-resources/src/main/resources/freemarker/screenshots.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/screenshots.ftl
@@ -7,21 +7,7 @@
     <title>Home</title>
     <link rel="shortcut icon" href="favicon.ico" >
     <link href="css/core.css" rel="stylesheet" type="text/css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
+    <style type="text/css">
 	#slider {
 	    position:relative;
 	    width:1000px; /* Change this to your images width */

--- a/thucydides-report-resources/src/main/resources/freemarker/treemap.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/treemap.ftl
@@ -11,22 +11,6 @@
         -->
     </style>
     <link href="css/core.css" rel="stylesheet" type="text/css"/>
-    <style type="text/css">a:link {
-        text-decoration: none;
-    }
-
-    a:visited {
-        text-decoration: none;
-    }
-
-    a:hover {
-        text-decoration: none;
-    }
-
-    a:active {
-        text-decoration: none;
-    }
-    </style>
 
 	<!-- CSS Files -->
 	<link type="text/css" href="jit/css/base.css" rel="stylesheet" />

--- a/thucydides-report-resources/src/main/resources/report-resources/css/core.css
+++ b/thucydides-report-resources/src/main/resources/report-resources/css/core.css
@@ -4,6 +4,21 @@
     margin:0;
     padding:0;
 }
+a:link {
+    text-decoration: none;
+}
+
+a:visited {
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: none;
+}
+
+a:active {
+    text-decoration: none;
+}
 
 #logo
 {


### PR DESCRIPTION
Moving the anchor styles from the template files into the stylesheet. I couldn't see a reason to have them outside the stylesheet, but please let me know if I missed something.
