### PR TITLE
THUCYDIDES-173 use either locale to format string or default to US

### DIFF
--- a/thucydides-core/src/test/groovy/net/thucydides/core/reports/WhenObtainingResultSummariesFromTestOutcomes.groovy
+++ b/thucydides-core/src/test/groovy/net/thucydides/core/reports/WhenObtainingResultSummariesFromTestOutcomes.groovy
@@ -5,7 +5,15 @@ import spock.lang.Specification
 import static net.thucydides.core.util.TestResources.directoryInClasspathCalled
 
 class WhenObtainingResultSummariesFromTestOutcomes extends Specification {
+    def currentLocale = Locale.getDefault()
 
+    def setup() {
+        Locale.setDefault(Locale.US)
+    }
+
+    def cleanup() {
+        Locale.setDefault(currentLocale)
+    }
     def loader = new TestOutcomeLoader()
 
     def "should count the number of successful tests in a set"() {

--- a/thucydides-core/src/test/java/net/thucydides/core/model/WhenCalculatingStoryCoverage.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/model/WhenCalculatingStoryCoverage.java
@@ -11,6 +11,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
+import java.text.NumberFormat;
 import java.util.List;
 
 import static net.thucydides.core.model.TestStepFactory.forABrokenTestStepCalled;
@@ -352,9 +353,9 @@ public class WhenCalculatingStoryCoverage {
         featureResults.recordStoryResults(storyResults);
         featureResults.recordStoryResults(storyResults2);
 
-        assertThat(featureResults.getFormatted().getPercentFailingCoverage(), is("37.5%"));
-        assertThat(featureResults.getFormatted().getPercentPassingCoverage(), is("12.5%"));
-        assertThat(featureResults.getFormatted().getPercentPendingCoverage(), is("50%"));
+        assertThat(featureResults.getFormatted().getPercentFailingCoverage(), is(locallyFormatedPercent(0.375, 1)));
+        assertThat(featureResults.getFormatted().getPercentPassingCoverage(), is(locallyFormatedPercent(0.125, 1)));
+        assertThat(featureResults.getFormatted().getPercentPendingCoverage(), is(locallyFormatedPercent(0.5, 0)));
     }
 
     @Test
@@ -490,6 +491,12 @@ public class WhenCalculatingStoryCoverage {
         featureResults.recordStoryResults(storyResults2);
 
         assertThat(featureResults.getCoverage(), is(0.0));
+    }
+
+    private String locallyFormatedPercent(double value, int maxFractionDigits) {
+        NumberFormat pct = NumberFormat.getPercentInstance();
+        pct.setMinimumFractionDigits(maxFractionDigits);
+        return pct.format(value);
     }
 
     private StoryTestResults testResultsFor(Class<?> storyClass,

--- a/thucydides-core/src/test/java/net/thucydides/core/reports/html/WhenFormattingForHTML.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/reports/html/WhenFormattingForHTML.java
@@ -1,25 +1,26 @@
 package net.thucydides.core.reports.html;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import net.thucydides.core.issues.IssueTracking;
 import net.thucydides.core.model.NumericalFormatter;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.MockEnvironmentVariables;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Mockito.when;
 
 public class WhenFormattingForHTML {
+
+    private Locale currentLocale;
 
     @Mock
     IssueTracking issueTracking;
@@ -27,6 +28,13 @@ public class WhenFormattingForHTML {
     @Before
     public void prepareFormatter() {
         MockitoAnnotations.initMocks(this);
+        currentLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @After
+    public void after() {
+        Locale.setDefault(currentLocale);
     }
 
     @Test


### PR DESCRIPTION
Uses 2 strategies:
WhenObtainingResultSummariesFromTestOutcomes and WhenFormattingForHTML => we force the use of US locale (we are checking the formatter, so we use any locale (US) and verify the string)
WhenCalculatingStoryCoverage => we compare result using the current Locale (we got the result from the webbrowser and we want to check the value is accurate, not that it specifically match any locale)

with this, the tests are passing independently of the locale used by the machine running the test.
To modify the current locale, use java user.country and user.language, either using argLine with maven or passing it to the jvm when running test in an IDE
