### PR TITLE
update pom to rely only on specified Selenium version 

### DIFF
--- a/thucydides-core/pom.xml
+++ b/thucydides-core/pom.xml
@@ -92,7 +92,17 @@
         <dependency>
             <groupId>com.github.detro.ghostdriver</groupId>
             <artifactId>phantomjsdriver</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
+             <exclusions>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-remote-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-java</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
@@ -876,11 +876,6 @@ public class WebElementFacadeImpl implements WebElementFacade {
 	}
 
     @Override
-    public Point getLocationOnScreenOnceScrolledIntoView() {
-        return new Point(0,0);
-    }
-
-    @Override
 	public Coordinates getCoordinates() {
 		return  ((Locatable) getElement()).getCoordinates();
 	}


### PR DESCRIPTION
selenium-remote-driver was version 2.31 while everything else was 2.33
got rid of getLocationOnScreenOnceScrolledIntoView() - removed from 2.31
