### PR TITLE
Fixed issue with URLs for test details on main report page throwing a 404

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/model/ReportNamer.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/model/ReportNamer.java
@@ -1,7 +1,6 @@
 package net.thucydides.core.model;
 
 import net.thucydides.core.digest.Digest;
-import net.thucydides.core.model.features.ApplicationFeature;
 import net.thucydides.core.util.NameConverter;
 import org.apache.commons.lang3.StringUtils;
 

--- a/thucydides-core/src/main/java/net/thucydides/core/model/Story.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/model/Story.java
@@ -5,11 +5,6 @@ import net.thucydides.core.model.features.ApplicationFeature;
 import net.thucydides.core.util.EqualsUtils;
 import net.thucydides.core.util.NameConverter;
 
-import java.util.Arrays;
-import java.util.List;
-
-import static ch.lambdaj.Lambda.index;
-import static ch.lambdaj.Lambda.joinFrom;
 import static net.thucydides.core.model.ReportType.ROOT;
 
 /**
@@ -105,6 +100,12 @@ public class Story {
                                final String featureClassName, final String featureName) {
         return new Story(storyId, storyName, featureClassName, featureName, null);
     }
+
+
+  public static Story withIdAndPathAndFeature(final String storyId, final String storyName, String storyPath,
+                             final String featureClassName, final String featureName) {
+    return new Story(storyId, storyName, featureClassName, featureName, storyPath);
+  }
 
 
     @Override

--- a/thucydides-core/src/main/java/net/thucydides/core/model/TestOutcome.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/model/TestOutcome.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;

--- a/thucydides-core/src/main/java/net/thucydides/core/reports/xml/TestOutcomeConverter.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/reports/xml/TestOutcomeConverter.java
@@ -439,7 +439,7 @@ public class TestOutcomeConverter implements Converter {
         if (feature == null) {
             story = Story.withIdAndPath(storyId, storyName,storyPath);
         } else {
-            story = Story.withId(storyId, storyName, feature.getId(), feature.getName());
+            story = Story.withIdAndPathAndFeature(storyId, storyName, storyPath, feature.getId(), feature.getName());
         }
         testOutcome.setUserStory(story);
     }

--- a/thucydides-core/src/test/java/net/thucydides/core/reports/WhenNamingTheReports.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/reports/WhenNamingTheReports.java
@@ -4,7 +4,6 @@ import net.thucydides.core.annotations.Feature;
 import net.thucydides.core.annotations.Story;
 import net.thucydides.core.digest.Digest;
 import net.thucydides.core.model.TestOutcome;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Test;
 
 import static net.thucydides.core.model.ReportType.HTML;

--- a/thucydides-core/src/test/java/net/thucydides/core/reports/integration/WhenReadingAnXMLReport.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/reports/integration/WhenReadingAnXMLReport.java
@@ -293,7 +293,7 @@ public class WhenReadingAnXMLReport {
     public void should_load_feature_details_from_xml_file() throws Exception {
         String storedReportXML =
             "<acceptance-test-run title='Should do this' name='should_do_this' steps='1' successful='1' failures='0' skipped='0' ignored='0' pending='0' result='SUCCESS'>\n"
-          + "  <user-story id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AUserStory' name='A user story'>\n"
+          + "  <user-story id='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport.AUserStory' name='A user story' path='net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport'>\n"
           + "    <feature id='myapp.myfeatures.SomeFeature' name='Some feature' />\n"
           + "  </user-story>"
           + "  <test-step result='SUCCESS'>\n"
@@ -310,6 +310,7 @@ public class WhenReadingAnXMLReport {
         ApplicationFeature expectedFeature = new ApplicationFeature("myapp.myfeatures.SomeFeature", "Some feature");
         assertThat(testOutcome.get().getFeature().getId(), is("myapp.myfeatures.SomeFeature"));
         assertThat(testOutcome.get().getFeature().getName(), is("Some feature"));
+        assertThat(testOutcome.get().getPath(), is("net.thucydides.core.reports.integration.WhenGeneratingAnXMLReport"));
     }
 
     @Test


### PR DESCRIPTION
While unmarshalling TestOutcome from XML files, the path was not set if the user story had a feature. This was making the report name different in freemarker template.
