### PR TITLE
fix upload file to method when use selenium grid

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
@@ -2,6 +2,7 @@ package net.thucydides.core.pages;
 
 import ch.lambdaj.function.convert.Converter;
 import com.google.common.base.Predicate;
+import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.annotations.WhenPageOpens;
 import net.thucydides.core.fluent.ThucydidesFluentAdapter;
 import net.thucydides.core.guice.Injectors;
@@ -133,7 +134,11 @@ public abstract class PageObject {
     }
 
     public FileToUpload upload(final String filename) {
-        return new FileToUpload(filename);
+        return new FileToUpload(filename).useRemoteDriver(isDefinedRemoteUrl());
+    }
+
+    private boolean isDefinedRemoteUrl() {
+        return ThucydidesSystemProperty.REMOTE_URL.isDefinedIn(pages.getConfiguration().getEnvironmentVariables());
     }
 
     private void setupPageUrls() {

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/components/FileToUpload.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/components/FileToUpload.java
@@ -3,6 +3,8 @@ package net.thucydides.core.pages.components;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
 
 import java.io.File;
 import java.net.URL;
@@ -16,6 +18,7 @@ public class FileToUpload {
     static final String WINDOWS_PATH_PATTERN = "^[A-Z]:\\\\.*";
 
     private static Pattern fullWindowsPath = Pattern.compile(WINDOWS_PATH_PATTERN);
+    private boolean remoteDriver = false;
 
     public FileToUpload(final String filename) {
         if (isOnTheClasspath(filename)) {
@@ -62,7 +65,25 @@ public class FileToUpload {
 
 
     public void to(final WebElement uploadFileField) {
-        uploadFileField.sendKeys(osSpecificPathOf(filename));
+        if (isRemoteDriver()) {
+            LocalFileDetector detector = new LocalFileDetector();
+            File localFile = detector.getLocalFile(osSpecificPathOf(filename));
+            if (uploadFileField instanceof RemoteWebElement)
+                ((RemoteWebElement) uploadFileField).setFileDetector(detector);
+            String absolutePath = localFile.getAbsolutePath();
+            uploadFileField.sendKeys(absolutePath);
+        } else {
+            uploadFileField.sendKeys(osSpecificPathOf(filename));
+        }
+    }
+
+    public boolean isRemoteDriver() {
+        return remoteDriver;
+    }
+
+    public FileToUpload useRemoteDriver(boolean remoteDriver) {
+        this.remoteDriver = remoteDriver;
+        return this;
     }
 
 

--- a/thucydides-core/src/test/java/net/thucydides/core/webdriver/integration/WhenUploadingFiles.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/webdriver/integration/WhenUploadingFiles.java
@@ -1,13 +1,13 @@
 package net.thucydides.core.webdriver.integration;
 
 import net.thucydides.core.pages.PageObject;
+import net.thucydides.core.pages.Pages;
 import net.thucydides.core.pages.components.FileToUpload;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.htmlunit.HtmlUnitDriver;
 import org.openqa.selenium.support.FindBy;
 
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verify;
 
 public class WhenUploadingFiles {
 
-    public class UploadPage extends PageObject {
+    public static class UploadPage extends PageObject {
 
         @FindBy(name = "upload")
         public WebElement uploadField;
@@ -38,10 +38,12 @@ public class WhenUploadingFiles {
     }
 
     private static WebDriver driver;
+    private static Pages pageFactory;
 
     @BeforeClass
     public static void open_local_static_site() {
         driver = new HtmlUnitDriver();
+        pageFactory = new Pages(driver);
         openStaticTestSite(driver);
     }
 
@@ -59,7 +61,7 @@ public class WhenUploadingFiles {
 
     @Test
     public void should_upload_a_file_from_the_resources_directory() {
-        UploadPage uploadPage = new UploadPage(driver);
+        UploadPage uploadPage = pageFactory.get(UploadPage.class);
 
         uploadPage.uploadFile("uploads/readme.txt");
 
@@ -69,7 +71,7 @@ public class WhenUploadingFiles {
 
     @Test
     public void should_upload_a_file_from_the_classpath() {
-        UploadPage uploadPage = new UploadPage(driver);
+        UploadPage uploadPage = pageFactory.get(UploadPage.class);
 
         uploadPage.uploadFile("/report-resources/css/core.css");
 
@@ -128,16 +130,16 @@ public class WhenUploadingFiles {
         File currentDirectory = new File(System.getProperty("user.dir"));
         File targetDirectory = new File(currentDirectory, "target");
         File uploadedFile = new File(targetDirectory, "upload.txt");
-        writeTextToFile("Hi there", uploadedFile);
+        writeTextToFile(uploadedFile);
 
-        UploadPage uploadPage = new UploadPage(driver);
+        UploadPage uploadPage = pageFactory.get(UploadPage.class);
 
         uploadPage.uploadFile("target/upload.txt");
 
         assertThat(uploadPage.uploadField.getAttribute("value"), containsString("upload.txt"));
     }
 
-    private void writeTextToFile(String text, File uploadedFile) throws IOException {
+    private void writeTextToFile(File uploadedFile) throws IOException {
         PrintWriter out = new PrintWriter(uploadedFile);
         out.close();
     }


### PR DESCRIPTION
Old upload().to() method did not work when you use Selenium Grid. Because first need upload file to remote machine where is running Selenium Node with browser. 
I fix existing tests with upload files. But have no idea have to create test with using Selenium Grid.
But this solution is work on my own Selenium Grid more then one month.
