### PR TITLE
Change from gmaven to groovy-eclipse-compiler.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,14 +62,30 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
+                <version>3.1</version>
                 <configuration>
                     <showDeprecation>false</showDeprecation>
                     <showWarnings>true</showWarnings>
                     <optimize>true</optimize>
                     <source>1.6</source>
                     <target>1.6</target>
+                    <compilerId>groovy-eclipse-compiler</compilerId>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.8.0-01</version>
+                        <type>maven-plugin</type>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>2.0.7-03</version>
+                        <!-- this version must be correct match for groovy.version - 
+                            see http://groovy.codehaus.org/Groovy-Eclipse+compiler+plugin+for+Maven -->
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -171,40 +187,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <providerSelection>1.8</providerSelection>
-                    <source />
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.gmaven.runtime</groupId>
-                        <artifactId>gmaven-runtime-1.8</artifactId>
-                        <version>1.4</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>${groovy.version}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/thucydides-core/pom.xml
+++ b/thucydides-core/pom.xml
@@ -47,11 +47,6 @@
             <version>1.6</version>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
-        </dependency>
-        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.4</version>

--- a/thucydides-easyb-integration-tests/pom.xml
+++ b/thucydides-easyb-integration-tests/pom.xml
@@ -16,22 +16,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <providerSelection>1.7</providerSelection>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>compile</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>

--- a/thucydides-easyb-plugin/pom.xml
+++ b/thucydides-easyb-plugin/pom.xml
@@ -23,44 +23,6 @@
                     <threadCount>10</threadCount>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>gmaven-plugin</artifactId>
-                <version>1.4</version>
-                <configuration>
-                    <providerSelection>1.7</providerSelection>
-                    <source />
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generateStubs</goal>
-                            <goal>compile</goal>
-                            <goal>generateTestStubs</goal>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.codehaus.gmaven.runtime</groupId>
-                        <artifactId>gmaven-runtime-1.7</artifactId>
-                        <version>1.3</version>
-                        <exclusions>
-                            <exclusion>
-                                <groupId>org.codehaus.groovy</groupId>
-                                <artifactId>groovy-all</artifactId>
-                            </exclusion>
-                        </exclusions>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.codehaus.groovy</groupId>
-                        <artifactId>groovy-all</artifactId>
-                        <version>${groovy.version}</version>
-                        <scope>compile</scope>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
     <dependencies>
@@ -128,7 +90,14 @@
 		                    <storyReport>target/easyb/easyb.html</storyReport>
 		                    <easybTestDirectory>src/test/stories</easybTestDirectory>
 		                </configuration>
-		            </plugin>			
+		            </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-compiler</artifactId>
+                        <version>2.8.0-01</version>
+                        <extensions>true</extensions>
+                        <!-- add Groovy source folder src/main/groovy (not auto-detected if src/main/java doesn't exist) -->
+                    </plugin>
 				</plugins>
 			</build>
 		</profile>


### PR DESCRIPTION
GMaven seems to be discontinued (see http://groovy.github.io/gmaven/) in favour of groovy-eclipse-compiler, which is better supported by (recent versions of) Eclipse and m2e anyway.

It requires the update to maven-compiler-plugin 3.1; whether this or the use of groovy-eclipse-compiler I'm not sure but maven now prints a lot of compiler warnings which weren't there before (even though you already had showWarnings=true).

For simplicity I've set the groovy-eclipse-compiler to be used by default whenever maven-compiler-plugin runs (i.e. compile and testCompile), and this works fine in all cases except where there is no src/xyz/java in which case it doesn't spot src/xyz/groovy; there are a few ways round this (described on http://groovy.codehaus.org/Groovy-Eclipse+compiler+plugin+for+Maven) and I've picked one of them and just added it to thucydides-easyb-plugin for the moment.  Could move this to the top-level POM if needed.
