### PR TITLE
One more fix for 'safari via saucelabs' problem. Will allow to run the t...

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/webdriver/WebDriverFactory.java
@@ -294,18 +294,21 @@ public class WebDriverFactory {
 
     private void setAppropriateSaucelabsPlatformVersionForSafari(DesiredCapabilities capabilities)
     {
-        String browserVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
-        if (browserVersion.equals("5"))
+        if (ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables).equalsIgnoreCase("mac"))
         {
-            capabilities.setCapability("platform", "OS X 10.6");
-        }
-        else if (browserVersion.equals("6"))
-        {
-            capabilities.setCapability("platform", "OS X 10.8");
-        }
-        else if (browserVersion.equals("7"))
-        {
-            capabilities.setCapability("platform", "OS X 10.9");
+            String browserVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
+            if (browserVersion.equals("5"))
+            {
+                capabilities.setCapability("platform", "OS X 10.6");
+            }
+            else if (browserVersion.equals("6"))
+            {
+                capabilities.setCapability("platform", "OS X 10.8");
+            }
+            else if (browserVersion.equals("7"))
+            {
+                capabilities.setCapability("platform", "OS X 10.9");
+            }
         }
     }
 


### PR DESCRIPTION
...ests on non-mac platforms as usually. Actually there's only one non-mac option: safari on windows 7.
