### PR TITLE
fix "PageObject" method "waitForTextToAppear(final WebElement element,final String expectedText)

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
@@ -269,7 +269,7 @@ public abstract class PageObject {
     }
 
     /**
-     * Waits for a given text to appear anywhere on the page.
+     * Waits for a given text to appear inside the element.
      */
     public PageObject waitForTextToAppear(final WebElement element,
                                           final String expectedText) {
@@ -278,7 +278,7 @@ public abstract class PageObject {
     }
 
     /**
-     * Waits for a given text to appear anywhere on the page.
+     * Waits for a given text to disappear from the element.
      */
     public PageObject waitForTextToDisappear(final WebElement element,
                                              final String expectedText) {

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/RenderedPageObjectView.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/RenderedPageObjectView.java
@@ -178,12 +178,7 @@ class RenderedPageObjectView {
     }
 
     public boolean containsText(final WebElement element, final String textValue) {
-        String textInBody = String.format("//body[contains(.,\"%s\")]", textValue);
-        List<WebElement> elements = element.findElements(By.xpath(textInBody));
-        if (foundNo(elements)) {
-            return false;
-        }
-        return true;
+        return element.getText().contains(textValue);
     }
 
     private ExpectedCondition<Boolean> textNotPresent(final String expectedText) {


### PR DESCRIPTION
Inside the method "containsText" we don't find text inside the element which we send as parameter, because of locator starts with "//body". Thus we check all text nodes, but we need wait for text of only one element.
