### PR TITLE
skip stale element reference exception during waitUntilVisible()

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
@@ -620,12 +620,7 @@ public class WebElementFacadeImpl implements WebElementFacade {
     private ExpectedCondition<Boolean> elementIsDisplayed() {
         return new ExpectedCondition<Boolean>() {
             public Boolean apply(WebDriver driver) {
-                try {
-                    return (getElement() != null) && (getElement().isDisplayed());
-                } catch (NullPointerException e) {
-                    // Selenium sometimes throws a NPE if the element is not present at all on the page.
-                    return false;
-                }
+                return isCurrentlyVisible();
             }
         };
     }


### PR DESCRIPTION
I noticed that waitUntilVisible() throws "stale element reference". 
So I think that all exceptions should be block in any waiter. Only after timeout we can throw Timeout exception.
Do we need change behaviour of other waiters to block all exceptions or it must be so?
