### PR TITLE
Fix "currently" method

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/annotations/locators/SmartAjaxElementLocator.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/annotations/locators/SmartAjaxElementLocator.java
@@ -19,14 +19,6 @@ import java.util.List;
 public class SmartAjaxElementLocator extends SmartElementLocator {
 	protected final int timeOutInSeconds;
 	private final Clock clock;
-	private static final List<String> QUICK_METHODS = Arrays.asList("isCurrentlyVisible",
-			"isCurrentlyEnabled",
-			"waitUntilVisible",
-			"waitUntilEnabled",
-			"shouldNotBeVisible");
-
-	private static final List<String> QUICK_CLASSES = Arrays.asList(WebElementFacadeImpl.class.getName(), PageObject.class.getName());
-
 	private final Field field;
 	private final WebDriver driver;
 
@@ -65,8 +57,7 @@ public class SmartAjaxElementLocator extends SmartElementLocator {
 
 	private boolean calledFromAQuickMethod() {
         for (StackTraceElement elt : Thread.currentThread().getStackTrace()) {
-            if (QUICK_METHODS.contains(elt.getMethodName())
-                    && QUICK_CLASSES.contains(elt.getClassName())) {
+            if (elt.getMethodName().contains("Currently")) {
                 return true;
             }
         }

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
@@ -248,8 +248,8 @@ public class WebElementFacadeImpl implements WebElementFacade {
      * Is this web element present and visible on the screen
      * This method will not throw an exception if the element is not on the screen at all.
      * The method will fail immediately if the element is not visible on the screen.
-     * There is a little black magic going on here - the web element class will detect if it is being called
-     * by a method called "isCurrently*" and, if so, fail immediately without waiting as it would normally do.
+     * SmartAjaxElementLocator check that method name contains "Currently"
+     * and, if so, fail immediately without waiting as it would normally do.
      */
     @Override
 	public boolean isCurrentlyVisible() {


### PR DESCRIPTION
The current behavior is not consistent with comment above method isCurrentlyVisible():

I have removed constant QUICK_METHODS (I don't understand why this list contains "shouldNotBeVisible" and don't "shouldNotBeCurrentlyVisible") and QUICK_CLASSES, which cannot be changed by users.
For example if I extends WebElementFacadeImpl and overide isCurrentlyVisible method, I will be waiting for implicit timeout.
Also I cannot  find any cases when we execute method from PageObject.class.

Thus it would be better to make the behavior more clear. 
But it's also bad implementation because of we go throughout all stacktrace method! And it can cause problems with the chain of fluent method.
