### PR TITLE
Changed BrowserMobFixtureService getProxyServer method access modifier type to public

### DIFF
--- a/thucydides-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
+++ b/thucydides-browsermob-plugin/src/main/java/net/thucydides/browsermob/fixtureservices/BrowserMobFixtureService.java
@@ -51,7 +51,7 @@ public class BrowserMobFixtureService implements FixtureService {
         }
     }
 
-    protected ProxyServer getProxyServer() {
+    public ProxyServer getProxyServer() {
         return threadLocalproxyServer.get();
     }
 

--- a/thucydides-core/src/main/java/net/thucydides/core/fixtureservices/ClasspathFixtureProviderService.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/fixtureservices/ClasspathFixtureProviderService.java
@@ -11,16 +11,19 @@ import java.util.ServiceLoader;
  */
 public class ClasspathFixtureProviderService implements FixtureProviderService {
 
+    private List<FixtureService> fixtureServices;
+
     @Override
     public List<FixtureService> getFixtureServices() {
-        List<FixtureService> fixtureServices = new ArrayList<FixtureService>();
+        if (fixtureServices == null) {
+            fixtureServices = new ArrayList<FixtureService>();
 
-        ServiceLoader<FixtureService> fixtureServiceLoader = ServiceLoader.load(FixtureService.class);
+            ServiceLoader<FixtureService> fixtureServiceLoader = ServiceLoader.load(FixtureService.class);
 
-        for (FixtureService fixtureService : fixtureServiceLoader) {
-            fixtureServices.add(fixtureService);
+            for (FixtureService fixtureService : fixtureServiceLoader) {
+                fixtureServices.add(fixtureService);
+            }
         }
-
         return fixtureServices;
     }
 }


### PR DESCRIPTION
Now, actually there is no way to get the running proxy server instance because getProxyServer method had protected access modifier type.
Also, updated ClasspathFixtureServiceProviderService getFixtureServices method to get already stored fixture services.
