### PR TITLE
override SmartAjaxElementLocator toString method

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/annotations/locators/SmartAjaxElementLocator.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/annotations/locators/SmartAjaxElementLocator.java
@@ -237,5 +237,10 @@ public class SmartAjaxElementLocator extends SmartElementLocator {
 		}
 	}
 
-
+    @Override
+    public String toString() {
+        SmartAnnotations annotations = new SmartAnnotations(field);
+        By by = annotations.buildBy();
+        return by.toString();
+    }
 }


### PR DESCRIPTION
override SmartAjaxElementLocator toString method to get access to text of element locator in waitFor methods of WebElementFacadeImpl.

For example I want wait until element with annotation @FindBy(css = ".navbar [href$='/members/login']") be visible for 15 seconds and get message: element with locator By.selector: .navbar [href$='/members/login'] is not visble.

At the moment I use
throw new ElementNotVisibleException("Element with locator ["+locator.toString();+"] is not visible!"); 

result: "Element with locator ["net.thucydides.core.annotations.locators.SmartAjaxElementLocator@23897e13"] is not visible!"

with overrided toString we get: "Element with locator ["By.selector: .navbar [href$='/members/login']"] is not visible!"

Thus inside WebElementFacadeImpl we can use locator.toString(); to get clear text
