### PR TITLE
Fixed NPE bug in flush() 

### DIFF
--- a/thucydides-junit/src/main/java/net/thucydides/junit/runners/RetryFilteringRunNotifier.java
+++ b/thucydides-junit/src/main/java/net/thucydides/junit/runners/RetryFilteringRunNotifier.java
@@ -67,7 +67,9 @@ public class RetryFilteringRunNotifier extends RunNotifierDecorator {
             super.fireTestIgnored(lastIgnored);
         }
 
-        super.fireTestFinished(lastDescription);
+        if (lastDescription != null) {
+            super.fireTestFinished(lastDescription);
+        }
     }
 
     public void reset() {


### PR DESCRIPTION
When tests are marked with @Ignore, an NPE will sometimes be thrown at the end of the test run, causing it to look like it's failed when it hasn't. This fix should prevent this from happening.
