### PR TITLE
THUCYDIDES-160: update test resources used from jbehave unit tests

### DIFF
--- a/thucydides-sample-alternative-resources/src/main/java/net/thucydides/jbehave/SomeBoilerplateSteps.java
+++ b/thucydides-sample-alternative-resources/src/main/java/net/thucydides/jbehave/SomeBoilerplateSteps.java
@@ -1,8 +1,11 @@
 package net.thucydides.jbehave;
 
+import org.junit.Ignore;
+
 /**
  * A sample resource step class used in the JBehave unit tests.
  */
+@Ignore // this annotation is used in the JBehave unit tests, so please don't remove it
 public class SomeBoilerplateSteps {
 //    @Given("a system state")
 //    public void givenASystemState() {


### PR DESCRIPTION
The JBehave tests related to this class were broken because they expected this class to be annotated with @Given.
