### PR TITLE
Update test to reference renamed folder

### DIFF
--- a/thucydides-core/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnAggregateHtmlReportSet.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/reports/integration/WhenGeneratingAnAggregateHtmlReportSet.java
@@ -201,7 +201,7 @@ public class WhenGeneratingAnAggregateHtmlReportSet {
 
     @Test(expected = TestOutcomesFailures.class)
     public void should_throw_an_exception_when_asked_if_failures_are_present() {
-        File reports = directoryInClasspathCalled("/test-outcomes/containing-failures");
+        File reports = directoryInClasspathCalled("/test-outcomes/containing-failure");
         ResultChecker resultChecker = new ResultChecker(reports);
         resultChecker.checkTestResults();
     }


### PR DESCRIPTION
It would appear this folder got renamed somewhere along the line, and this test wasn't updated accordingly.