### PR TITLE
error.png was change to cross.png

### DIFF
--- a/thucydides-report-resources/src/main/resources/freemarker/screenshots.ftl
+++ b/thucydides-report-resources/src/main/resources/freemarker/screenshots.ftl
@@ -76,7 +76,7 @@
 <#-- HEADER
 -->
 <#if testOutcome.result == "FAILURE"><#assign outcome_icon = "fail.png"><#assign outcome_text = "failing-color">
-<#elseif testOutcome.result == "ERROR"><#assign outcome_icon = "error.png"><#assign outcome_text = "error-color">
+<#elseif testOutcome.result == "ERROR"><#assign outcome_icon = "cross.png"><#assign outcome_text = "error-color">
 <#elseif testOutcome.result == "SUCCESS"><#assign outcome_icon = "success.png"><#assign outcome_text = "success-color">
 <#elseif testOutcome.result == "PENDING"><#assign outcome_icon = "pending.png"><#assign outcome_text = "pending-color">
 <#else><#assign outcome_icon = "ignor.png"><#assign outcome_text = "ignore-color">


### PR DESCRIPTION
Link to file error.png was change to cross.png because error.png not exist in images.
