### PR TITLE
When the thucydides.jquery.integration property is set to false, jQuery ...

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/PageObject.java
@@ -860,7 +860,7 @@ public abstract class PageObject {
     public void addJQuerySupport() {
         if (pageIsLoaded()) {
             JQueryEnabledPage jQueryEnabledPage = JQueryEnabledPage.withDriver(getDriver());
-            if (!jQueryEnabledPage.isJQueryEnabled()) {
+            if (jQueryEnabledPage.isJQueryIntegrationEnabled() && !jQueryEnabledPage.isJQueryAvailable()) {
                 jQueryEnabledPage.injectJQuery();
                 jQueryEnabledPage.injectJQueryPlugins();
             }

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/WebElementFacadeImpl.java
@@ -828,7 +828,7 @@ public class WebElementFacadeImpl implements WebElementFacade {
 
     private void enableHighlightingIfRequired() {
         JQueryEnabledPage jQueryEnabledPage = JQueryEnabledPage.withDriver(driver);
-        if (jQueryEnabledPage.isJQueryEnabled()) {
+        if (jQueryEnabledPage.isJQueryIntegrationEnabled() && !jQueryEnabledPage.isJQueryAvailable()) {
             jQueryEnabledPage.injectJQueryPlugins();
         }
     }

--- a/thucydides-core/src/main/java/net/thucydides/core/pages/jquery/JQueryEnabledPage.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/pages/jquery/JQueryEnabledPage.java
@@ -31,11 +31,15 @@ public class JQueryEnabledPage {
         return new JQueryEnabledPage(driver);
     }
 
-    public boolean isJQueryEnabled() {
-        boolean jqueryIntegrationEnabled =
-                    Boolean.valueOf(ThucydidesSystemProperty.THUCYDIDES_JQUERY_INTEGRATION
-                                                            .from(environmentVariables,"true"));
+	public boolean isJQueryIntegrationEnabled(){
+		boolean jqueryIntegrationEnabled =
+				Boolean.valueOf(ThucydidesSystemProperty.THUCYDIDES_JQUERY_INTEGRATION
+						.from(environmentVariables,"true"));
+		return jqueryIntegrationEnabled;
+	}
 
+    public boolean isJQueryAvailable() {
+        boolean jqueryIntegrationEnabled = isJQueryIntegrationEnabled();
         if (jqueryIntegrationEnabled && javascriptIsSupportedIn(driver)) {
             JavascriptExecutorFacade js = new JavascriptExecutorFacade(driver);
             Boolean result = (Boolean) js.executeScript("return (typeof jQuery === 'function')");

--- a/thucydides-core/src/test/java/net/thucydides/core/pages/jquery/WhenAddingJQuerySupportToPageObjects.java
+++ b/thucydides-core/src/test/java/net/thucydides/core/pages/jquery/WhenAddingJQuerySupportToPageObjects.java
@@ -118,7 +118,7 @@ public class WhenAddingJQuerySupportToPageObjects {
     public void should_not_add_the_jquery_library_to_a_page_if_jquery_integration_is_deactivated() {
         environmentVariables.setProperty("thucydides.jquery.integration", "false");
 
-        assertThat(page.isJQueryEnabled(), is(false));
+        assertThat(page.isJQueryIntegrationEnabled(), is(false));
     }
 
 }


### PR DESCRIPTION
...injection should not happen.

The way it is now, jQuery injection will still happen even if we set the thucydides.jquery.integration property to false because the isJQueryEnabled() function does two things:
1. Check the value of the property.
2. Check if jQuery is already loaded.
