### PR TITLE
Execute tests on Safari 7 (SauceLabs)

### DIFF
--- a/thucydides-core/src/main/java/net/thucydides/core/webdriver/capabilities/SauceRemoteDriverCapabilities.java
+++ b/thucydides-core/src/main/java/net/thucydides/core/webdriver/capabilities/SauceRemoteDriverCapabilities.java
@@ -12,6 +12,7 @@ import org.openqa.selenium.remote.DesiredCapabilities;
 import java.lang.reflect.Method;
 
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 /**
  * Provide Sauce Labs specific capabilities
@@ -22,7 +23,7 @@ public class SauceRemoteDriverCapabilities implements RemoteDriverCapabilities {
 
     private final EnvironmentVariables environmentVariables;
 
-    public SauceRemoteDriverCapabilities(EnvironmentVariables environmentVariables){
+    public SauceRemoteDriverCapabilities(EnvironmentVariables environmentVariables) {
         this.environmentVariables = environmentVariables;
     }
 
@@ -46,39 +47,53 @@ public class SauceRemoteDriverCapabilities implements RemoteDriverCapabilities {
     }
 
     private void configureBrowserVersion(DesiredCapabilities capabilities) {
-        String driverVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
+        String driverVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION
+                .from(environmentVariables);
         if (isNotEmpty(driverVersion)) {
             capabilities.setCapability("version", driverVersion);
         }
     }
 
     private void configureTargetPlatform(DesiredCapabilities capabilities) {
-        String platformValue = ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables);
-        if (isNotEmpty(platformValue)) {
-            capabilities.setCapability("platform", platformFrom(platformValue));
-        }
-        if (capabilities.getBrowserName().equals("safari"))
-        {
+        setAppropriateSaucelabsPlatformVersion(capabilities);
+        if (capabilities.getBrowserName().equals("safari")) {
             setAppropriateSaucelabsPlatformVersionForSafari(capabilities);
         }
     }
 
-    private void setAppropriateSaucelabsPlatformVersionForSafari(DesiredCapabilities capabilities)
-    {
-        if (ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables).equalsIgnoreCase("mac"))
-        {
-            String browserVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION.from(environmentVariables);
-            if (browserVersion.equals("5"))
-            {
+    private void setAppropriateSaucelabsPlatformVersion(DesiredCapabilities capabilities) {
+        String platformValue = ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM
+                .from(environmentVariables);
+        if (isEmpty(platformValue)) {
+            return;
+        }
+        if (platformValue.equalsIgnoreCase("snowleopard")) {
+            capabilities.setCapability("platform", "OS X 10.6");
+        } else if (platformValue.equalsIgnoreCase("mountainlion")) {
+            capabilities.setCapability("platform", "OS X 10.8");
+        } else if (platformValue.equalsIgnoreCase("mavericks")) {
+            capabilities.setCapability("platform", "OS X 10.9");
+        } else if (platformValue.equalsIgnoreCase("yosemite")) {
+            capabilities.setCapability("platform", "OS X 10.10");
+        } else {
+            capabilities.setCapability("platform", platformFrom(platformValue));
+
+        }
+    }
+
+    private void setAppropriateSaucelabsPlatformVersionForSafari(DesiredCapabilities capabilities) {
+        if (ThucydidesSystemProperty.SAUCELABS_TARGET_PLATFORM.from(environmentVariables)
+                .equalsIgnoreCase("mac")) {
+            String browserVersion = ThucydidesSystemProperty.SAUCELABS_DRIVER_VERSION
+                    .from(environmentVariables);
+            if (browserVersion.equals("5")) {
                 capabilities.setCapability("platform", "OS X 10.6");
-            }
-            else if (browserVersion.equals("6"))
-            {
+            } else if (browserVersion.equals("6")) {
                 capabilities.setCapability("platform", "OS X 10.8");
-            }
-            else if (browserVersion.equals("7"))
-            {
+            } else if (browserVersion.equals("7")) {
                 capabilities.setCapability("platform", "OS X 10.9");
+            } else if (browserVersion.equals("8")) {
+                capabilities.setCapability("platform", "OS X 10.10");
             }
         }
     }


### PR DESCRIPTION
Fix a bug that did not allow you to execute tests on Safari 7 on SauceLabs, it always tries to run test on Safari 7 X MAC 10.6 and it fails
