### PR TITLE
This small change makes Thucydides compatible with Firefox version 32 or greater

### DIFF
--- a/thucydides-core/pom.xml
+++ b/thucydides-core/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>17.0</version>
+            <version>18.0</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>


### PR DESCRIPTION
Guava 18.0 is already specified in Gradle.
